### PR TITLE
feat: Update ActivationMetaDataDto to include RA officer activation and bumped swagger version.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,16 @@
+# Build SPI Documentation
+
+This guide describes how to build the SPI documentation for the BankID App activation.
+
+
+To build a new version of the documentation, 
+1. Change the java code and create a PR.
+2. The pipeline builds the documentation automatically and places it in the `docs` directory on deploy.
+3. If you want to see the generated files locally, run the following command in the root directory of the project:
+
+`mvn clean compile -f outgoingra`
+
+The result will be placed in docs catalogue.
+
+
+

--- a/README.md
+++ b/README.md
@@ -25,9 +25,3 @@ For information about API keys, product activation, etc see [Getting Started](..
 For API documentation and development guidelines please see our [BankID app API guide](../main/bankid-app-api.md).
 
 You can peruse the SPI reference documentation as [Swagger](https://bankidnorge.github.io/bankid-app-activation-spi/) or [ReDoc](https://bankidnorge.github.io/bankid-app-activation-spi/redoc.html).
-
-Building this documentation, run 
-
-`mvn clean compile -f outgoingra`
-
-the result will be placed in docs catalogue 

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/NotifyUserOfActivationRequestBodyDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/NotifyUserOfActivationRequestBodyDTO.java
@@ -37,10 +37,11 @@ public class NotifyUserOfActivationRequestBodyDTO extends AuthenticationBodyDTO 
                 "<li> - activation_code: A single activation code provided over a secure channel. </li>" +
                 "<li> - selfservice: Activation codes provided over two insecure channels. </li>" +
                 "<li> - bankid_auth: Activation through a BankID authentication. </li>" +
+                "<li> - raofficer_activation: Activation through RA officer of the bank. </li>" +
                 "</ul>", example = "selfservice"
         )
         public enum FlowType {
-            activation_code, selfservice, bankid_auth
+            activation_code, selfservice, bankid_auth, raofficer_activation
         }
 
         public FlowType flow;

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
@@ -27,7 +27,7 @@ import static no.bankid.outgoing.ra.HttpSignatureHeaders.SIGNATURE;
 @OpenAPIDefinition(
         info = @Info(
                 title = "BankID RA Service Provider Interface (SPI) for activation of BankID App",
-                version = "1.2.0",
+                version = "1.3.0",
                 description = """
                         Defines the interface to be provided by a Registration Authority service to \
                         support activation of BankID App as a HA2 element for an end user's Netcentric BankID.\


### PR DESCRIPTION
Added the `flow_type` `raofficer_activation` to the `ActivationMetaDataDto`. 
This is required so that we can call the RA's to send message to the user with correct activation method.