### PR TITLE
Revert "feat: Update ActivationMetaDataDto to include RA officer acti"

### DIFF
--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/NotifyUserOfActivationRequestBodyDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/NotifyUserOfActivationRequestBodyDTO.java
@@ -37,11 +37,10 @@ public class NotifyUserOfActivationRequestBodyDTO extends AuthenticationBodyDTO 
                 "<li> - activation_code: A single activation code provided over a secure channel. </li>" +
                 "<li> - selfservice: Activation codes provided over two insecure channels. </li>" +
                 "<li> - bankid_auth: Activation through a BankID authentication. </li>" +
-                "<li> - raofficer_activation: Activation through RA officer of the bank. </li>" +
                 "</ul>", example = "selfservice"
         )
         public enum FlowType {
-            activation_code, selfservice, bankid_auth, raofficer_activation
+            activation_code, selfservice, bankid_auth
         }
 
         public FlowType flow;

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/RaRequirements.java
@@ -27,7 +27,7 @@ import static no.bankid.outgoing.ra.HttpSignatureHeaders.SIGNATURE;
 @OpenAPIDefinition(
         info = @Info(
                 title = "BankID RA Service Provider Interface (SPI) for activation of BankID App",
-                version = "1.3.0",
+                version = "1.4.0",
                 description = """
                         Defines the interface to be provided by a Registration Authority service to \
                         support activation of BankID App as a HA2 element for an end user's Netcentric BankID.\


### PR DESCRIPTION
Removed `raofficer_activation` from `ActivationMetaDataDto.FlowType` because the new SPI does not provide a reference to the phone number (msisdn), so we cannot notify the user as intended. RA can use audit message for notifications instead.