### PR TITLE
Fix Swagger example for CheckUserIdentityVerificationResponseDTO

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -933,7 +933,7 @@
           },
           "error" : {
             "type" : "string",
-            "description" : "Error code if verification failed. Possible values: - INVALID (verification code does not match, user may retry), - EXPIRED (verification code has expired, RA System needs to handle expiration time), - CONSUMED (verification code has already been successfully used). This field MUST be present when `verified=false` and MUST be absent when `verified=true`.",
+            "description" : "Error code if verification failed. Possible values:<ul><li>INVALID - verification code does not match, user may retry</li><li>EXPIRED - verification code has expired, RA System needs to handle expiration time</li><li>CONSUMED - verification code has already been successfully used</li></ul>This field MUST be present when verified is false and MUST be absent when verified is true.",
             "example" : "INVALID",
             "enum" : [ "INVALID", "EXPIRED", "CONSUMED" ]
           }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -928,7 +928,7 @@
         "properties" : {
           "verified" : {
             "type" : "boolean",
-            "description" : "verified true when provided code is matched and will be false if there is any error i-e: INVALID, EXPIRED or CONSUMED",
+            "description" : "True when the provided code matches; false if there is an error, i.e. INVALID, EXPIRED, or CONSUMED.",
             "example" : false
           },
           "error" : {
@@ -973,7 +973,7 @@
             "maxLength" : 1024,
             "minLength" : 6,
             "type" : "string",
-            "description" : "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6-digits. In the future, it may be changed to a string with a length between 6-1024 characters.",
+            "description" : "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6 digits. In the future, it may be changed to a string with a length between 6 and 1024 characters.",
             "example" : "123456"
           }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -973,7 +973,7 @@
             "maxLength" : 1024,
             "minLength" : 6,
             "type" : "string",
-            "description" : "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6 digits. In the future, it may be changed to a string with a length between 6 and 1024 characters.",
+            "description" : "Verification code provided by RA Officer to user. Currently expected to be a 6-digit numeric string, but the schema accepts strings between 6 and 1024 characters for forward-compatibility.",
             "example" : "123456"
           }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -928,11 +928,13 @@
         "properties" : {
           "verified" : {
             "type" : "boolean",
-            "description" : "Whether the verification code was valid and has been consumed. When true, the error field will be absent. When false, the error field MUST be present."
+            "description" : "verified true when provided code is matched and will be false if there is any error i-e: INVALID, EXPIRED or CONSUMED",
+            "example" : false
           },
           "error" : {
             "type" : "string",
-            "description" : "Error code if verification failed (only present when verified=false). Possible values: INVALID (verification code does not match, user may retry), EXPIRED (verification code has expired, codes expire after 15 minutes), CONSUMED (verification code has already been successfully used). This field MUST be present when verified=false and MUST be absent when verified=true.",
+            "description" : "Error code if verification failed. Possible values: - INVALID (verification code does not match, user may retry), - EXPIRED (verification code has expired, RA System needs to handle expiration time), - CONSUMED (verification code has already been successfully used). This field MUST be present when `verified=false` and MUST be absent when `verified=true`.",
+            "example" : "INVALID",
             "enum" : [ "INVALID", "EXPIRED", "CONSUMED" ]
           }
         },
@@ -971,7 +973,7 @@
             "maxLength" : 1024,
             "minLength" : 6,
             "type" : "string",
-            "description" : "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6-digits. In the future, it may be changed to a string with a length of 6-1024 characters.",
+            "description" : "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6-digits. In the future, it may be changed to a string with a length between 6-1024 characters.",
             "example" : "123456"
           }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -933,7 +933,7 @@
           },
           "error" : {
             "type" : "string",
-            "description" : "Error code if verification failed. Possible values:<ul><li>INVALID - verification code does not match, user may retry</li><li>EXPIRED - verification code has expired, RA System needs to handle expiration time</li><li>CONSUMED - verification code has already been successfully used</li></ul>This field MUST be present when verified is false and MUST be absent when verified is true.",
+            "description" : "Error code if verification failed. Possible values:<ul><li>INVALID - verification code does not match, user may retry</li><li>EXPIRED - verification code has expired</li><li>CONSUMED - verification code has already been successfully used</li></ul>This field MUST be present when verified is false and MUST be absent when verified is true.",
             "example" : "INVALID",
             "enum" : [ "INVALID", "EXPIRED", "CONSUMED" ]
           }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -820,17 +820,17 @@ components:
       properties:
         verified:
           type: boolean
-          description: "Whether the verification code was valid and has been consumed.\
-            \ When true, the error field will be absent. When false, the error field\
-            \ MUST be present."
+          description: "verified true when provided code is matched and will be false\
+            \ if there is any error i-e: INVALID, EXPIRED or CONSUMED"
+          example: false
         error:
           type: string
-          description: "Error code if verification failed (only present when verified=false).\
-            \ Possible values: INVALID (verification code does not match, user may\
-            \ retry), EXPIRED (verification code has expired, codes expire after 15\
-            \ minutes), CONSUMED (verification code has already been successfully\
-            \ used). This field MUST be present when verified=false and MUST be absent\
-            \ when verified=true."
+          description: "Error code if verification failed. Possible values: - INVALID\
+            \ (verification code does not match, user may retry), - EXPIRED (verification\
+            \ code has expired, RA System needs to handle expiration time), - CONSUMED\
+            \ (verification code has already been successfully used). This field MUST\
+            \ be present when `verified=false` and MUST be absent when `verified=true`."
+          example: INVALID
           enum:
           - INVALID
           - EXPIRED
@@ -876,7 +876,7 @@ components:
           type: string
           description: "Verification code provided by RA Officer to user. Currently\
             \ the code MUST be a string of 6-digits. In the future, it may be changed\
-            \ to a string with a length of 6-1024 characters."
+            \ to a string with a length between 6-1024 characters."
           example: "123456"
       description: Request body for checking user identity verification from RA officer.
     StatusBappResponseDTO:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -875,8 +875,8 @@ components:
           minLength: 6
           type: string
           description: "Verification code provided by RA Officer to user. Currently\
-            \ the code MUST be a string of 6 digits. In the future, it may be changed\
-            \ to a string with a length between 6 and 1024 characters."
+            \ expected to be a 6-digit numeric string, but the schema accepts strings\
+            \ between 6 and 1024 characters for forward-compatibility."
           example: "123456"
       description: Request body for checking user identity verification from RA officer.
     StatusBappResponseDTO:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -827,10 +827,9 @@ components:
           type: string
           description: "Error code if verification failed. Possible values:<ul><li>INVALID\
             \ - verification code does not match, user may retry</li><li>EXPIRED -\
-            \ verification code has expired, RA System needs to handle expiration\
-            \ time</li><li>CONSUMED - verification code has already been successfully\
-            \ used</li></ul>This field MUST be present when verified is false and\
-            \ MUST be absent when verified is true."
+            \ verification code has expired</li><li>CONSUMED - verification code has\
+            \ already been successfully used</li></ul>This field MUST be present when\
+            \ verified is false and MUST be absent when verified is true."
           example: INVALID
           enum:
           - INVALID

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -825,11 +825,12 @@ components:
           example: false
         error:
           type: string
-          description: "Error code if verification failed. Possible values: - INVALID\
-            \ (verification code does not match, user may retry), - EXPIRED (verification\
-            \ code has expired, RA System needs to handle expiration time), - CONSUMED\
-            \ (verification code has already been successfully used). This field MUST\
-            \ be present when `verified=false` and MUST be absent when `verified=true`."
+          description: "Error code if verification failed. Possible values:<ul><li>INVALID\
+            \ - verification code does not match, user may retry</li><li>EXPIRED -\
+            \ verification code has expired, RA System needs to handle expiration\
+            \ time</li><li>CONSUMED - verification code has already been successfully\
+            \ used</li></ul>This field MUST be present when verified is false and\
+            \ MUST be absent when verified is true."
           example: INVALID
           enum:
           - INVALID

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -820,8 +820,8 @@ components:
       properties:
         verified:
           type: boolean
-          description: "verified true when provided code is matched and will be false\
-            \ if there is any error i-e: INVALID, EXPIRED or CONSUMED"
+          description: "True when the provided code matches; false if there is an\
+            \ error, i.e. INVALID, EXPIRED, or CONSUMED."
           example: false
         error:
           type: string
@@ -875,8 +875,8 @@ components:
           minLength: 6
           type: string
           description: "Verification code provided by RA Officer to user. Currently\
-            \ the code MUST be a string of 6-digits. In the future, it may be changed\
-            \ to a string with a length between 6-1024 characters."
+            \ the code MUST be a string of 6 digits. In the future, it may be changed\
+            \ to a string with a length between 6 and 1024 characters."
           example: "123456"
       description: Request body for checking user identity verification from RA officer.
     StatusBappResponseDTO:

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationRequestBodyDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationRequestBodyDTO.java
@@ -15,8 +15,8 @@ public class CheckUserIdentityVerificationRequestBodyDTO extends AuthenticationB
     public UUID activation_id;
 
     @Schema(
-            description = "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6 digits. In the " +
-                    "future, it may be changed to a string with a length between 6 and 1024 characters.",
+            description = "Verification code provided by RA Officer to user. Currently expected to be a 6-digit numeric string, " +
+                    "but the schema accepts strings between 6 and 1024 characters for forward-compatibility.",
             example = "123456",
             requiredMode = REQUIRED,
             minLength = 6,

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationRequestBodyDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationRequestBodyDTO.java
@@ -15,8 +15,8 @@ public class CheckUserIdentityVerificationRequestBodyDTO extends AuthenticationB
     public UUID activation_id;
 
     @Schema(
-            description = "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6-digits. In the " +
-                    "future, it may be changed to a string with a length between 6-1024 characters.",
+            description = "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6 digits. In the " +
+                    "future, it may be changed to a string with a length between 6 and 1024 characters.",
             example = "123456",
             requiredMode = REQUIRED,
             minLength = 6,

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationRequestBodyDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationRequestBodyDTO.java
@@ -15,7 +15,8 @@ public class CheckUserIdentityVerificationRequestBodyDTO extends AuthenticationB
     public UUID activation_id;
 
     @Schema(
-            description = "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6-digits. In the future, it may be changed to a string with a length of 6-1024 characters.",
+            description = "Verification code provided by RA Officer to user. Currently the code MUST be a string of 6-digits. In the " +
+                    "future, it may be changed to a string with a length between 6-1024 characters.",
             example = "123456",
             requiredMode = REQUIRED,
             minLength = 6,

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
@@ -5,24 +5,32 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-@Schema(description = "Response from identity verification check. The code is consumed only upon successful verification. Failed attempts (INVALID) do not consume the code, allowing the user to retry.")
+@Schema(description = "Response from identity verification check. The code is consumed only upon successful verification. Failed " +
+        "attempts (INVALID) do not consume the code, allowing the user to retry.")
 public class CheckUserIdentityVerificationResponseDTO {
+
+    @Schema(
+            description = "verified true when provided code is matched and will be false if there is any error i-e: INVALID, EXPIRED or" +
+                    " CONSUMED",
+            example = "false",
+            requiredMode = REQUIRED
+    )
+    public boolean verified;
+    @Schema(
+            description = "Error code if verification failed. " +
+                    "Possible values: " +
+                    "- INVALID (verification code does not match, user may retry), " +
+                    "- EXPIRED (verification code has expired, RA System needs to handle expiration time), " +
+                    "- CONSUMED (verification code has already been successfully used). " +
+                    "This field MUST be present when `verified=false` and MUST be absent when `verified=true`.",
+            example = "INVALID",
+            requiredMode = NOT_REQUIRED
+    )
+    public ErrorCode error;
 
     public enum ErrorCode {
         INVALID,
         EXPIRED,
         CONSUMED
     }
-
-    @Schema(
-            description = "Whether the verification code was valid and has been consumed. When true, the error field will be absent. When false, the error field MUST be present.",
-            requiredMode = REQUIRED
-    )
-    public boolean verified;
-
-    @Schema(
-            description = "Error code if verification failed (only present when verified=false). Possible values: INVALID (verification code does not match, user may retry), EXPIRED (verification code has expired, codes expire after 15 minutes), CONSUMED (verification code has already been successfully used). This field MUST be present when verified=false and MUST be absent when verified=true.",
-            requiredMode = NOT_REQUIRED
-    )
-    public ErrorCode error;
 }

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
@@ -16,12 +16,13 @@ public class CheckUserIdentityVerificationResponseDTO {
     )
     public boolean verified;
     @Schema(
-            description = "Error code if verification failed. " +
-                    "Possible values: " +
-                    "- INVALID (verification code does not match, user may retry), " +
-                    "- EXPIRED (verification code has expired, RA System needs to handle expiration time), " +
-                    "- CONSUMED (verification code has already been successfully used). " +
-                    "This field MUST be present when `verified=false` and MUST be absent when `verified=true`.",
+            description = "Error code if verification failed. Possible values:" +
+                    "<ul>" +
+                    "<li>INVALID - verification code does not match, user may retry</li>" +
+                    "<li>EXPIRED - verification code has expired, RA System needs to handle expiration time</li>" +
+                    "<li>CONSUMED - verification code has already been successfully used</li>" +
+                    "</ul>" +
+                    "This field MUST be present when verified is false and MUST be absent when verified is true.",
             example = "INVALID",
             requiredMode = NOT_REQUIRED
     )

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
@@ -19,7 +19,7 @@ public class CheckUserIdentityVerificationResponseDTO {
             description = "Error code if verification failed. Possible values:" +
                     "<ul>" +
                     "<li>INVALID - verification code does not match, user may retry</li>" +
-                    "<li>EXPIRED - verification code has expired, RA System needs to handle expiration time</li>" +
+                    "<li>EXPIRED - verification code has expired</li>" +
                     "<li>CONSUMED - verification code has already been successfully used</li>" +
                     "</ul>" +
                     "This field MUST be present when verified is false and MUST be absent when verified is true.",

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
@@ -10,8 +10,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 public class CheckUserIdentityVerificationResponseDTO {
 
     @Schema(
-            description = "verified true when provided code is matched and will be false if there is any error i-e: INVALID, EXPIRED or" +
-                    " CONSUMED",
+            description = "True when the provided code matches; false if there is an error, i.e. INVALID, EXPIRED, or CONSUMED.",
             example = "false",
             requiredMode = REQUIRED
     )


### PR DESCRIPTION
This pull request updates the documentation and data transfer object (DTO) descriptions for the user identity verification process to improve clarity and consistency across the OpenAPI (Swagger) specifications and Java DTOs. The changes mainly focus on making the descriptions more explicit about the meaning of the `verified` and `error` fields, providing examples, and aligning the wording across YAML, JSON, and Java annotations.

**Documentation and DTO description improvements:**

* Updated the description of the `verified` field in both Swagger files (`swagger.yaml`, `swagger.json`) and in the Java DTO (`CheckUserIdentityVerificationResponseDTO`) to clearly state that `verified` is true only when the provided code matches, and false if there is any error (INVALID, EXPIRED, or CONSUMED). Added example values for clarity. [[1]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L931-R937) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L823-R833) [[3]](diffhunk://#diff-54246f35e0a2b85dc9438a0de05c54c4baa7cc49b5e321d6a3dfd6865575f084L8-R35)
* Improved the description of the `error` field in Swagger files and Java DTO to explicitly list possible error values, clarify when the field is present, and provide example values. [[1]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L931-R937) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L823-R833) [[3]](diffhunk://#diff-54246f35e0a2b85dc9438a0de05c54c4baa7cc49b5e321d6a3dfd6865575f084L8-R35)
* Clarified the description of the verification code format in both request DTOs and Swagger files, specifying that the code may be between 6 and 1024 characters in the future. [[1]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L974-R976) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L879-R879) [[3]](diffhunk://#diff-b775c050e742537042040f6c715bc3d17aace939accb7d3a4e38114f5c032d8fL18-R19)

**Code organization:**

* Moved the `ErrorCode` enum in `CheckUserIdentityVerificationResponseDTO` to the bottom of the class for better readability and consistency.