### PR TITLE
Omit error field from CheckUserIdentityVerificationResponseDTO when null

### DIFF
--- a/outgoingra/pom.xml
+++ b/outgoingra/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <swagger.version>2.2.28</swagger.version>
+        <jackson.version>2.17.2</jackson.version>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -29,6 +30,11 @@
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
+++ b/outgoingra/src/main/java/no/bankid/outgoing/ra/CheckUserIdentityVerificationResponseDTO.java
@@ -1,5 +1,6 @@
 package no.bankid.outgoing.ra;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
@@ -26,6 +27,7 @@ public class CheckUserIdentityVerificationResponseDTO {
             example = "INVALID",
             requiredMode = NOT_REQUIRED
     )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public ErrorCode error;
 
     public enum ErrorCode {


### PR DESCRIPTION
## Summary
- The OpenAPI contract for `CheckUserIdentityVerificationResponseDTO` states: *"This field [`error`] MUST be present when verified is false and MUST be absent when verified is true."*
- The generated DTO previously serialized `error` as explicit `null` (e.g. `{"verified": true, "error": null}`) instead of omitting the key, violating the "MUST be absent" rule.
- Add `@JsonInclude(JsonInclude.Include.NON_NULL)` on the `error` field so Jackson omits the key entirely when null.
- Add `jackson-annotations` as a compile dependency in `outgoingra/pom.xml` so the annotation is on the classpath.

## Why
Strict spec-conforming clients could reject `"error": null` (null for an enum-typed property). Existing clients (e.g. bapp-toba) tolerate both shapes since they null-check `getError()`, so this change is backwards compatible.

## Compatibility / SPI version
- No schema change: `error` is already `not required` in the OpenAPI spec; `required` lists are unchanged.
- No HTTP semantic changes.
- Strictly closer to the published contract — no SPI version bump needed; bugfix only.

## Test
- `mvn compile` succeeds in `outgoingra/`.
- The OpenAPI schema (`docs/swagger.json` / `docs/swagger.yaml`) is unchanged because `@JsonInclude` is a runtime serialization hint and not reflected in the schema.